### PR TITLE
Update readme to use currently active python rather than pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ CloudnetPy is a refactored fork of the currently operational (Matlab) processing
 
 ### From PyPI
 ```
-$ pip3 install cloudnetpy
+$ python3 -m pip install cloudnetpy
 ```
 
 ### From the source
@@ -32,7 +32,7 @@ $ git clone https://github.com/actris-cloudnet/cloudnetpy
 $ cd cloudnetpy/
 $ python3 -m venv venv
 $ source venv/bin/activate
-(venv) $ pip3 install .
+(venv) $ python3 -m pip install .
 ```
 
 ## Contributing


### PR DESCRIPTION
This changes the install invocation for both methods to make sure it uses the currently activate Python. Calling pip3 directly sometimes points to a system pip3, rather than for instance the anaconda installed. At least on my system with conda installed and a virtual environment, pip3 points to system pip, while this invocation will use the currently active one.