### PR TITLE
Return uuids of created files

### DIFF
--- a/cloudnetpy/categorize/categorize.py
+++ b/cloudnetpy/categorize/categorize.py
@@ -23,6 +23,9 @@ def generate_categorize(input_files, output_file, keep_uuid=False):
         output_file (str): Full path of the output file.
         keep_uuid (bool, optional): If True, keeps the UUID of the old file,
             if that exists. Default is False when new UUID is generated.
+    
+    Returns:
+        uuid: UUID of the generated file.
 
     Raises:
         RuntimeError: Failed to create the categorize file.

--- a/cloudnetpy/categorize/categorize.py
+++ b/cloudnetpy/categorize/categorize.py
@@ -84,8 +84,9 @@ def generate_categorize(input_files, output_file, keep_uuid=False):
     quality = classify.fetch_quality(radar, lidar, classification, attenuations)
     output_data = _prepare_output()
     output.update_attributes(output_data, CATEGORIZE_ATTRIBUTES)
-    _save_cat(output_file, radar, lidar, model, output_data, keep_uuid)
+    uuid = _save_cat(output_file, radar, lidar, model, output_data, keep_uuid)
     _close_all()
+    return uuid
 
 
 def _save_cat(file_name, radar, lidar, model, obs, keep_uuid):
@@ -100,6 +101,7 @@ def _save_cat(file_name, radar, lidar, model, obs, keep_uuid):
             'model_time': len(model.time),
             'model_height': len(model.mean_height)}
     rootgrp = output.init_file(file_name, dims, obs, keep_uuid)
+    uuid = rootgrp.file_uuid
     output.add_file_type(rootgrp, 'categorize')
     output.copy_global(radar.dataset, rootgrp, ('year', 'month', 'day', 'location'))
     rootgrp.title = f"Categorize file from {radar.location}"
@@ -109,6 +111,7 @@ def _save_cat(file_name, radar, lidar, model, obs, keep_uuid):
     output.merge_history(rootgrp, 'categorize', radar, lidar)
     _merge_source()
     rootgrp.close()
+    return uuid
 
 
 COMMENTS = {

--- a/cloudnetpy/categorize/categorize.py
+++ b/cloudnetpy/categorize/categorize.py
@@ -25,7 +25,7 @@ def generate_categorize(input_files, output_file, keep_uuid=False):
             if that exists. Default is False when new UUID is generated.
     
     Returns:
-        uuid: UUID of the generated file.
+        str: UUID of the generated file.
 
     Raises:
         RuntimeError: Failed to create the categorize file.

--- a/cloudnetpy/instruments/ceilo.py
+++ b/cloudnetpy/instruments/ceilo.py
@@ -44,7 +44,7 @@ def ceilo2nc(input_file, output_file, site_meta, keep_uuid=False):
     _append_data(ceilo, beta_variants)
     _append_height(ceilo, site_meta['altitude'])
     output.update_attributes(ceilo.data, ATTRIBUTES)
-    _save_ceilo(ceilo, output_file, site_meta['name'], keep_uuid)
+    return _save_ceilo(ceilo, output_file, site_meta['name'], keep_uuid)
 
 
 def _initialize_ceilo(file, site_name):
@@ -102,6 +102,7 @@ def _save_ceilo(ceilo, output_file, location, keep_uuid):
     dims = {'time': len(ceilo.time),
             'range': len(ceilo.range)}
     rootgrp = output.init_file(output_file, dims, ceilo.data, keep_uuid)
+    uuid = rootgrp.file_uuid
     output.add_file_type(rootgrp, 'lidar')
     if hasattr(ceilo, 'dataset'):
         output.copy_variables(ceilo.dataset, rootgrp, ('wavelength',))
@@ -111,6 +112,7 @@ def _save_ceilo(ceilo, output_file, location, keep_uuid):
     rootgrp.history = f"{utils.get_time()} - ceilometer file created"
     rootgrp.source = ceilo.model
     rootgrp.close()
+    return uuid
 
 
 ATTRIBUTES = {

--- a/cloudnetpy/instruments/ceilo.py
+++ b/cloudnetpy/instruments/ceilo.py
@@ -29,7 +29,7 @@ def ceilo2nc(input_file, output_file, site_meta, keep_uuid=False):
             if that exists. Default is False when new UUID is generated.
     
     Returns:
-        uuid: UUID of the generated file.
+        str: UUID of the generated file.
 
     Raises:
         RuntimeError: Failed to read or process raw ceilometer data.

--- a/cloudnetpy/instruments/ceilo.py
+++ b/cloudnetpy/instruments/ceilo.py
@@ -27,6 +27,9 @@ def ceilo2nc(input_file, output_file, site_meta, keep_uuid=False):
             (metres above mean sea level).
         keep_uuid (bool, optional): If True, keeps the UUID of the old file,
             if that exists. Default is False when new UUID is generated.
+    
+    Returns:
+        uuid: UUID of the generated file.
 
     Raises:
         RuntimeError: Failed to read or process raw ceilometer data.

--- a/cloudnetpy/instruments/mira.py
+++ b/cloudnetpy/instruments/mira.py
@@ -40,7 +40,7 @@ def mira2nc(mmclx_file, output_file, site_meta, rebin_data=False, keep_uuid=Fals
     raw_mira.screen_by_snr(snr_gain)
     raw_mira.add_meta()
     output.update_attributes(raw_mira.data, MIRA_ATTRIBUTES)
-    _save_mira(mmclx_file, raw_mira, output_file, keep_uuid)
+    return _save_mira(mmclx_file, raw_mira, output_file, keep_uuid)
 
 
 class Mira(DataSource):
@@ -119,6 +119,7 @@ def _save_mira(mmclx_file, raw_radar, output_file, keep_uuid):
     dims = {'time': len(raw_radar.time),
             'range': len(raw_radar.range)}
     rootgrp = output.init_file(output_file, dims, raw_radar.data, keep_uuid)
+    uuid = rootgrp.file_uuid
     fields_from_raw = ('nfft', 'prf', 'nave', 'zrg', 'rg0', 'drg')
     output.copy_variables(netCDF4.Dataset(mmclx_file), rootgrp, fields_from_raw)
     output.add_file_type(rootgrp, 'radar')
@@ -128,6 +129,7 @@ def _save_mira(mmclx_file, raw_radar, output_file, keep_uuid):
     rootgrp.history = f"{utils.get_time()} - radar file created"
     rootgrp.source = raw_radar.source
     rootgrp.close()
+    return uuid
 
 
 def _find_measurement_date(raw_radar):

--- a/cloudnetpy/instruments/mira.py
+++ b/cloudnetpy/instruments/mira.py
@@ -24,6 +24,9 @@ def mira2nc(mmclx_file, output_file, site_meta, rebin_data=False, keep_uuid=Fals
             Otherwise keeps the native resolution. Default is False.
         keep_uuid (bool, optional): If True, keeps the UUID of the old file,
             if that exists. Default is False when new UUID is generated.
+    
+    Returns:
+        uuid: UUID of the generated file.
 
     Examples:
           >>> from cloudnetpy.instruments import mira2nc

--- a/cloudnetpy/instruments/mira.py
+++ b/cloudnetpy/instruments/mira.py
@@ -26,7 +26,7 @@ def mira2nc(mmclx_file, output_file, site_meta, rebin_data=False, keep_uuid=Fals
             if that exists. Default is False when new UUID is generated.
     
     Returns:
-        uuid: UUID of the generated file.
+        str: UUID of the generated file.
 
     Examples:
           >>> from cloudnetpy.instruments import mira2nc

--- a/cloudnetpy/instruments/rpg.py
+++ b/cloudnetpy/instruments/rpg.py
@@ -37,7 +37,7 @@ def rpg2nc(path_to_l1_files, output_file, site_meta, keep_uuid=False):
     rpg = Rpg(one_day_of_data, site_meta)
     rpg.linear_to_db(('Ze', 'antenna_gain'))
     output.update_attributes(rpg.data, RPG_ATTRIBUTES)
-    _save_rpg(rpg, output_file, keep_uuid)
+    return _save_rpg(rpg, output_file, keep_uuid)
 
 
 def get_rpg_files(path_to_l1_files):
@@ -339,6 +339,7 @@ def _save_rpg(rpg, output_file, keep_uuid):
             'chirp_sequence': len(rpg.data['chirp_start_indices'][:])}
 
     rootgrp = output.init_file(output_file, dims, rpg.data, keep_uuid)
+    uuid = rootgrp.file_uuid
     output.add_file_type(rootgrp, 'radar')
     rootgrp.title = f"Radar file from {rpg.location}"
     rootgrp.year, rootgrp.month, rootgrp.day = rpg.date
@@ -346,6 +347,7 @@ def _save_rpg(rpg, output_file, keep_uuid):
     rootgrp.history = f"{utils.get_time()} - radar file created"
     rootgrp.source = rpg.source
     rootgrp.close()
+    return uuid
 
 
 DEFINITIONS = {

--- a/cloudnetpy/instruments/rpg.py
+++ b/cloudnetpy/instruments/rpg.py
@@ -23,6 +23,9 @@ def rpg2nc(path_to_l1_files, output_file, site_meta, keep_uuid=False):
         keep_uuid (bool, optional): If True, keeps the UUID of the old file,
             if that exists. Default is False when new UUID is generated.
 
+    Returns:
+        uuid: UUID of the generated file.
+
     Raises:
         RuntimeError: Failed to read the binary data.
 

--- a/cloudnetpy/instruments/rpg.py
+++ b/cloudnetpy/instruments/rpg.py
@@ -24,7 +24,7 @@ def rpg2nc(path_to_l1_files, output_file, site_meta, keep_uuid=False):
             if that exists. Default is False when new UUID is generated.
 
     Returns:
-        uuid: UUID of the generated file.
+        str: UUID of the generated file.
 
     Raises:
         RuntimeError: Failed to read the binary data.

--- a/cloudnetpy/output.py
+++ b/cloudnetpy/output.py
@@ -43,6 +43,7 @@ def save_product_file(short_id, obj, file_name, keep_uuid, copy_from_cat=()):
     dimensions = {'time': len(obj.time),
                   'height': len(obj.dataset.variables['height'])}
     root_group = init_file(file_name, dimensions, obj.data, keep_uuid)
+    uuid = root_group.file_uuid
     add_file_type(root_group, short_id)
     vars_from_source = ('altitude', 'latitude', 'longitude', 'time', 'height') + copy_from_cat
     copy_variables(obj.dataset, root_group, vars_from_source)
@@ -51,6 +52,7 @@ def save_product_file(short_id, obj, file_name, keep_uuid, copy_from_cat=()):
     copy_global(obj.dataset, root_group, ('location', 'day', 'month', 'year'))
     merge_history(root_group, identifier, obj)
     root_group.close()
+    return uuid
 
 
 def _get_identifier(short_id):

--- a/cloudnetpy/products/classification.py
+++ b/cloudnetpy/products/classification.py
@@ -19,6 +19,9 @@ def generate_classification(categorize_file, output_file, keep_uuid=False):
         output_file (str): Output file name.
         keep_uuid (bool, optional): If True, keeps the UUID of the old file,
             if that exists. Default is False when new UUID is generated.
+    
+    Returns:
+        uuid: UUID of the generated file.
 
     Examples:
         >>> from cloudnetpy.products import generate_classification

--- a/cloudnetpy/products/classification.py
+++ b/cloudnetpy/products/classification.py
@@ -32,8 +32,9 @@ def generate_classification(categorize_file, output_file, keep_uuid=False):
     status = _get_detection_status(categorize_bits)
     data_handler.append_data(status, 'detection_status')
     output.update_attributes(data_handler.data, CLASSIFICATION_ATTRIBUTES)
-    output.save_product_file('classification', data_handler, output_file, keep_uuid)
+    uuid = output.save_product_file('classification', data_handler, output_file, keep_uuid)
     data_handler.close()
+    return uuid
 
 
 def _get_target_classification(categorize_bits):

--- a/cloudnetpy/products/classification.py
+++ b/cloudnetpy/products/classification.py
@@ -21,7 +21,7 @@ def generate_classification(categorize_file, output_file, keep_uuid=False):
             if that exists. Default is False when new UUID is generated.
     
     Returns:
-        uuid: UUID of the generated file.
+        str: UUID of the generated file.
 
     Examples:
         >>> from cloudnetpy.products import generate_classification

--- a/cloudnetpy/products/drizzle.py
+++ b/cloudnetpy/products/drizzle.py
@@ -25,6 +25,9 @@ def generate_drizzle(categorize_file, output_file, keep_uuid=False):
         output_file (str): Output file name.
         keep_uuid (bool, optional): If True, keeps the UUID of the old file,
             if that exists. Default is False when new UUID is generated.
+    
+    Returns:
+        uuid: UUID of the generated file.
 
     Examples:
         >>> from cloudnetpy.products import generate_drizzle

--- a/cloudnetpy/products/drizzle.py
+++ b/cloudnetpy/products/drizzle.py
@@ -50,8 +50,9 @@ def generate_drizzle(categorize_file, output_file, keep_uuid=False):
     results['drizzle_retrieval_status'] = retrieval_status.retrieval_status
     _append_data(drizzle_source, results)
     output.update_attributes(drizzle_source.data, DRIZZLE_ATTRIBUTES)
-    output.save_product_file('drizzle', drizzle_source, output_file, keep_uuid)
+    uuid = output.save_product_file('drizzle', drizzle_source, output_file, keep_uuid)
     drizzle_source.close()
+    return uuid
 
 
 class DrizzleSource(DataSource):

--- a/cloudnetpy/products/drizzle.py
+++ b/cloudnetpy/products/drizzle.py
@@ -27,7 +27,7 @@ def generate_drizzle(categorize_file, output_file, keep_uuid=False):
             if that exists. Default is False when new UUID is generated.
     
     Returns:
-        uuid: UUID of the generated file.
+        str: UUID of the generated file.
 
     Examples:
         >>> from cloudnetpy.products import generate_drizzle

--- a/cloudnetpy/products/iwc.py
+++ b/cloudnetpy/products/iwc.py
@@ -27,6 +27,9 @@ def generate_iwc(categorize_file, output_file, keep_uuid=False):
         output_file (str): Output file name.
         keep_uuid (bool, optional): If True, keeps the UUID of the old file,
             if that exists. Default is False when new UUID is generated.
+    
+    Returns:
+        uuid: UUID of the generated file.
 
     Examples:
         >>> from cloudnetpy.products import generate_iwc

--- a/cloudnetpy/products/iwc.py
+++ b/cloudnetpy/products/iwc.py
@@ -29,7 +29,7 @@ def generate_iwc(categorize_file, output_file, keep_uuid=False):
             if that exists. Default is False when new UUID is generated.
     
     Returns:
-        uuid: UUID of the generated file.
+        str: UUID of the generated file.
 
     Examples:
         >>> from cloudnetpy.products import generate_iwc

--- a/cloudnetpy/products/iwc.py
+++ b/cloudnetpy/products/iwc.py
@@ -48,8 +48,9 @@ def generate_iwc(categorize_file, output_file, keep_uuid=False):
     _append_iwc_sensitivity(iwc_data)
     _append_iwc_status(iwc_data, ice_class)
     output.update_attributes(iwc_data.data, IWC_ATTRIBUTES)
-    output.save_product_file('iwc', iwc_data, output_file, keep_uuid)
+    uuid = output.save_product_file('iwc', iwc_data, output_file, keep_uuid)
     iwc_data.close()
+    return uuid
 
 
 class IwcSource(DataSource):

--- a/cloudnetpy/products/lwc.py
+++ b/cloudnetpy/products/lwc.py
@@ -27,7 +27,7 @@ def generate_lwc(categorize_file, output_file, keep_uuid=False):
             if that exists. Default is False when new UUID is generated.
     
     Returns:
-        uuid: UUID of the generated file.
+        str: UUID of the generated file.
 
     Examples:
         >>> from cloudnetpy.products import generate_lwc

--- a/cloudnetpy/products/lwc.py
+++ b/cloudnetpy/products/lwc.py
@@ -25,7 +25,9 @@ def generate_lwc(categorize_file, output_file, keep_uuid=False):
         output_file (str): Output file name.
         keep_uuid (bool, optional): If True, keeps the UUID of the old file,
             if that exists. Default is False when new UUID is generated.
-
+    
+    Returns:
+        uuid: UUID of the generated file.
 
     Examples:
         >>> from cloudnetpy.products import generate_lwc

--- a/cloudnetpy/products/lwc.py
+++ b/cloudnetpy/products/lwc.py
@@ -46,9 +46,10 @@ def generate_lwc(categorize_file, output_file, keep_uuid=False):
     error_obj = LwcError(lwc_source, lwc_obj)
     _append_data(lwc_source, lwc_obj, cloud_obj, error_obj)
     output.update_attributes(lwc_source.data, LWC_ATTRIBUTES)
-    output.save_product_file('lwc', lwc_source, output_file, keep_uuid,
+    uuid = output.save_product_file('lwc', lwc_source, output_file, keep_uuid,
                              copy_from_cat=('lwp', 'lwp_error'))
     lwc_source.close()
+    return uuid
 
 
 class LwcSource(DataSource):

--- a/cloudnetpy/version.py
+++ b/cloudnetpy/version.py
@@ -1,4 +1,4 @@
 MAJOR = 1
-MINOR = 0
-PATCH = 9
+MINOR = 1
+PATCH = 0
 __version__ = '%d.%d.%d' % (MAJOR, MINOR, PATCH)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-from .api import check_data_quality, check_metadata, run_unit_tests
+from .api import check_data_quality, check_metadata, check_is_valid_uuid, run_unit_tests

--- a/tests/api.py
+++ b/tests/api.py
@@ -1,6 +1,7 @@
 import subprocess
 import pytest
 from tests import utils
+from uuid import UUID
 
 
 def check_metadata(file, log_file=None):
@@ -37,6 +38,12 @@ def check_data_quality(file, log_file=None):
         subprocess.check_call([script, file, _validate_log_file(log_file)])
     except subprocess.CalledProcessError:
         raise
+
+def check_is_valid_uuid(uuid):
+    try:
+        uuid_obj = UUID(uuid, version=4)
+    except (ValueError, TypeError):
+        raise AssertionError(f'{uuid} is not a valid UUID.')
 
 
 def _validate_log_file(log_file):

--- a/tests/api.py
+++ b/tests/api.py
@@ -1,7 +1,7 @@
 import subprocess
+from uuid import UUID
 import pytest
 from tests import utils
-from uuid import UUID
 
 
 def check_metadata(file, log_file=None):
@@ -39,9 +39,10 @@ def check_data_quality(file, log_file=None):
     except subprocess.CalledProcessError:
         raise
 
+
 def check_is_valid_uuid(uuid):
     try:
-        uuid_obj = UUID(uuid, version=4)
+        UUID(uuid, version=4)
     except (ValueError, TypeError):
         raise AssertionError(f'{uuid} is not a valid UUID.')
 


### PR DESCRIPTION
This PR adds the following functionality:
- The functions that create NC files, such as `generate_categorize` and `ceilo2nc` now return UUIDs of the created files.