### PR TITLE
Added instrument information for ceilometer in Lindenberg (Germany)

### DIFF
--- a/cloudnetpy/instruments/jenoptik.py
+++ b/cloudnetpy/instruments/jenoptik.py
@@ -29,6 +29,10 @@ CEILOMETER_INFO = {
         calibration_factor=5.2e-12,
         overlap_function_params=(0, 1),
         is_range_corrected=True),
+    'lindenberg': instrument_info(
+        calibration_factor=2.5e-11,
+        overlap_function_params=(0, 1),
+        is_range_corrected=True),
 }
 
 


### PR DESCRIPTION
Added instrument information for Jenoptik ceilometer in Lindenberg:
- calibration factor value from U. Görsdorf (DWD Lindenberg, 17.09.2020)
- range correction is applied (also from U. Görsdorf)
- we were not quite sure about the overlap_function_params though. U. Görsdorf: "Beta_raw in the *.nc file is corrected regarding the overlap". We assumed overlap_function_params=(0, 1) and nothing looks out of the ordinary.