### PR TITLE
Fix flaky test_fix_old_data_2

### DIFF
--- a/tests/unit/test_meta_for_old_files.py
+++ b/tests/unit/test_meta_for_old_files.py
@@ -16,7 +16,13 @@ def test_fix_old_data():
 
 
 def test_fix_old_data_2():
+    global data_orig
     data, name = legacy_meta.fix_legacy_data(data_orig, 'detection_status')
     assert_array_equal(data_orig, data)
     assert ma.count(data) == 7
+
+    # Reset data_orig
+    data_orig = ma.array([[0, 1, 2],
+                          [3, 4, 5],
+                          [6, 7, 8]])
 


### PR DESCRIPTION
This PR aims to fix flaky `tests/unit/test_meta_for_old_files.py::test_fix_old_data_2`. In previous versions, the test will run into failure when running for multiple times. And the reason is that the status of `data_orig` is not cleared after modified by `fix_legacy_data`. The test failure can be reproduced by
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 tests/unit/test_meta_for_old_files.py::test_fix_old_data_2`