### PR TITLE
Fix flaky test_utils.py

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -63,6 +63,9 @@ def test_mdiff(input, output):
 ])
 def test_l2_norm(a, b, result):
     assert_array_almost_equal(utils.l2norm(a, b), result)
+    for arg in [a, b]:
+        if isinstance(arg, ma.MaskedArray):
+            arg[~arg.mask] = np.sqrt(arg[~arg.mask])
 
 
 class TestRebin2D:


### PR DESCRIPTION
This PR aims to fix flaky `tests/unit/test_util.py::test_l2_norm`. In previous versions, if parameterized with `(np.array([2, 3]), ma.array([3, 4], mask=[0, 1]), [np.sqrt(13), 3])`, the test will run into failure when running for multiple times. And the reason is that the function `utils.l2norm` will change the value of any `ma.MaskedArray` by the line `arg[~arg.mask] = arg[~arg.mask] ** 2`. That is to say, when a `ma.MaskedArray` is sent to compute some l2-norm, its own value will also get squared. I'm not sure whether that is expected in the source code, so I modified the test only. If you want to make sure the masked array's original value is not changed in the source function, I can definitely do that and make another PR.
The failure can be reproduced by:
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 tests/unit/test_utils.py::test_l2_norm`