### PR TITLE
Use `sldr` for insect detection

### DIFF
--- a/cloudnetpy/categorize/containers.py
+++ b/cloudnetpy/categorize/containers.py
@@ -50,12 +50,9 @@ class ClassData:
         self.z = data["radar"].data["Z"][:]
         self.v = data["radar"].data["v"][:]
         self.v_sigma = data["radar"].data["v_sigma"][:]
-        if "width" in data["radar"].data.keys():
-            self.width = data["radar"].data["width"][:]
-        if "ldr" in data["radar"].data.keys():
-            self.ldr = data["radar"].data["ldr"][:]
-        elif "slrd" in data["radar"].data.keys():
-            self.ldr = data["radar"].data["sldr"][:]
+        for key in ("width", "ldr", "sldr"):
+            if key in data["radar"].data.keys():
+                setattr(self, key, data["radar"].data[key][:])
         self.time = data["radar"].time
         self.height = data["radar"].height
         self.radar_type = data["radar"].type

--- a/cloudnetpy/categorize/insects.py
+++ b/cloudnetpy/categorize/insects.py
@@ -67,6 +67,7 @@ def _get_probabilities(obs: ClassData) -> dict:
         "z_strong": fun(obs.z, 0, 8, True),
         "z_weak": fun(obs.z, -20, 8, True),
         "ldr": fun(obs.ldr, -25, 5) if hasattr(obs, "ldr") else None,
+        "sldr": fun(obs.sldr, -25, 5) if hasattr(obs, "sldr") else None,
         "temp_loose": fun(obs.tw, 268, 2),
         "temp_strict": fun(obs.tw, 274, 1),
         "v": fun(smooth_v, -3.5, 2),
@@ -83,9 +84,15 @@ def _get_smoothed_v(obs: ClassData, sigma: Tuple[float, float] = (5, 5)) -> ma.M
 
 def _calc_prob_from_ldr(prob: dict) -> np.ndarray:
     """This is the most reliable proxy for insects."""
-    if prob["ldr"] is None:
-        return np.zeros(prob["z_strong"].shape)
-    return prob["ldr"] * prob["temp_loose"]
+    if prob["ldr"] is not None:
+        return prob["ldr"] * prob["temp_loose"]
+    if (
+        prob["sldr"] is not None
+    ):  # Strong SLDR values are probably insects, weak CAN be but not necessarily
+        p = prob["sldr"]
+        p[p < 0.9] = ma.masked
+        return p * prob["temp_loose"]
+    return np.zeros(prob["z_strong"].shape)
 
 
 def _calc_prob_from_all(prob: dict) -> np.ndarray:

--- a/cloudnetpy/categorize/melting.py
+++ b/cloudnetpy/categorize/melting.py
@@ -71,6 +71,7 @@ def find_melting_layer(obs: ClassData, smooth: bool = True) -> np.ndarray:
         v_prof = obs.v[ind, temp_indices]
 
         if ldr_diff is not None:
+            assert hasattr(obs, "ldr")
             ldr_prof = obs.ldr[ind, temp_indices]
             ldr_dprof = ldr_diff[ind, temp_indices]
 


### PR DESCRIPTION
High `sldr`values seem to be good proxy for insects. Using this improves the classification for pixels with strong backscatter from insects.

Without `sldr`: 

![20221030_galati_classification-fb4bdfba-target_classification](https://user-images.githubusercontent.com/18035491/203280071-10640263-6cc9-4a92-bb3e-e2b09bc38620.png)

With `sldr`

![galati-new](https://user-images.githubusercontent.com/18035491/203280347-1ca7859d-2898-4af0-baad-16186d34a4d3.png)

