### PR TITLE
Update mira.py

### DIFF
--- a/cloudnetpy/instruments/mira.py
+++ b/cloudnetpy/instruments/mira.py
@@ -1,5 +1,7 @@
 """Module for reading raw cloud radar data."""
+import logging
 import os
+from collections import OrderedDict
 from tempfile import TemporaryDirectory
 
 from cloudnetpy import concat_lib, output, utils
@@ -7,6 +9,111 @@ from cloudnetpy.exceptions import ValidTimeStampError
 from cloudnetpy.instruments.instruments import MIRA35
 from cloudnetpy.instruments.nc_radar import NcRadar
 from cloudnetpy.metadata import MetaData
+
+
+def _miraignorevar(filetype: str) -> list | None:
+    """Returns the vars to ignore for METEK MIRA-35 cloud radar concat.
+
+    This function return the nc variablenames that should be ignored when
+    concatting several files, a requirement needed when a path/list of files
+    can be passed in to mira2nc, at the moment (08.2023) only relevant for znc.
+
+    Args:
+        filetype: Either znc or mmclx
+
+    Returns:
+        Appropriate list of variables to ignore for the file type
+
+    Raises:
+        TypeError: Not a valid filetype given, must be string.
+        ValueError: Not a known filetype given, must be znc or mmclx
+
+    Examples:
+        not meant to be called directly by user
+
+    """
+    known_filetypes = ["znc", "mmclx"]
+    if not isinstance(filetype, str):
+        raise TypeError("Filetype must be string")
+
+    if filetype.lower() not in known_filetypes:
+        raise ValueError(f"Filetype must be one of {known_filetypes}")
+
+    keymaps = {"znc": ["DropSize"], "mmclx": None}
+
+    return keymaps.get(filetype.lower(), keymaps.get("mmclx"))
+
+
+def _mirakeymap(filetype: str) -> dict:
+    """Returns the ncvariables to cloudnetpy mapping for METEK MIRA-35 cloud radar.
+
+    This function return the approriate keymap (even for STSR polarimetric
+    config) for cloudnetpy to take the appropriate variables from the netCDF
+    whether mmclx (old format) or znc (new format).
+
+    Args:
+        filetype: Either znc or mmclx
+
+    Returns:
+        Appropriate keymap for the file type
+
+    Raises:
+        TypeError: Not a valid filetype given, must be string.
+        ValueError: Not a known filetype given, must be znc or mmclx
+
+    Examples:
+          not meant to be called directly by user
+
+    """
+    known_filetypes = ["znc", "mmclx"]
+    if not isinstance(filetype, str):
+        raise TypeError("Filetype must be string")
+
+    if filetype.lower() not in known_filetypes:
+        raise ValueError(f"Filetype must be one of {known_filetypes}")
+
+    # ordered dict here because that way the order is kept, which means
+    # we will get Zh2l over as Zh over Zg, which is relevant for the new
+    # znc files of an STSR radar
+    keymaps = {
+        "znc": OrderedDict(
+            [
+                ("Zg", "Zh"),
+                ("Zh2l", "Zh"),
+                ("VELg", "v"),
+                ("VELh2l", "v"),
+                ("RMSg", "width"),
+                ("RMSh2l", "width"),
+                ("LDRg", "ldr"),
+                ("LDRh2l", "ldr"),
+                ("SNRg", "SNR"),
+                ("SNRh2l", "SNR"),
+                ("elv", "elevation"),
+                ("azi", "azimuth_angle"),
+                ("aziv", "azimuth_velocity"),
+                ("nfft", "nfft"),
+                ("nave", "nave"),
+                ("prf", "prf"),
+                ("rg0", "rg0"),
+            ]
+        ),
+        "mmclx": {
+            "Zg": "Zh",
+            "VELg": "v",
+            "RMSg": "width",
+            "LDRg": "ldr",
+            "SNRg": "SNR",
+            "elv": "elevation",
+            "azi": "azimuth_angle",
+            "aziv": "azimuth_velocity",
+            "nfft": "nfft",
+            "nave": "nave",
+            "prf": "prf",
+            "rg0": "rg0",
+        },
+    }
+
+    return keymaps.get(filetype.lower(), keymaps["mmclx"])
 
 
 def mira2nc(
@@ -24,7 +131,8 @@ def mira2nc(
 
     Args:
         raw_mira: Filename of a daily MIRA .mmclx file. Can be also a folder containing
-            several non-concatenated .mmclx files from one day or list of files.
+            several non-concatenated .mmclx or .znc files from one day or list of files.
+            znc files take precedence because they are the newer filetype
         output_file: Output filename.
         site_meta: Dictionary containing information about the site. Required key
             value pair is `name`.
@@ -41,43 +149,64 @@ def mira2nc(
           >>> from cloudnetpy.instruments import mira2nc
           >>> site_meta = {'name': 'Vehmasmaki'}
           >>> mira2nc('raw_radar.mmclx', 'radar.nc', site_meta)
+          >>> mira2nc('raw_radar.znc', 'radar.nc', site_meta)
           >>> mira2nc('/one/day/of/mira/mmclx/files/', 'radar.nc', site_meta)
+          >>> mira2nc('/one/day/of/mira/znc/files/', 'radar.nc', site_meta)
 
     """
-    keymap = {
-        "Zg": "Zh",
-        "VELg": "v",
-        "RMSg": "width",
-        "LDRg": "ldr",
-        "SNRg": "SNR",
-        "elv": "elevation",
-        "azi": "azimuth_angle",
-        "aziv": "azimuth_velocity",
-        "nfft": "nfft",
-        "nave": "nave",
-        "prf": "prf",
-        "rg0": "rg0",
-    }
 
     with TemporaryDirectory() as temp_dir:
         if isinstance(raw_mira, list) or os.path.isdir(raw_mira):
-            mmclx_filename = f"{temp_dir}/tmp.mmclx"
+            # better naming would be concat_filename but to be directly comp-
+            # atible with the opening of the output we stick to input_filename
+            input_filename = f"{temp_dir}/tmp.mmclx"
+            # passed in is a list of files
             if isinstance(raw_mira, list):
-                valid_filenames = sorted(raw_mira)
+                valid_files = sorted(raw_mira)
             else:
-                valid_filenames = utils.get_sorted_filenames(raw_mira, ".mmclx")
-            valid_filenames = utils.get_files_with_common_range(valid_filenames)
+                # passed in is a path with potentially files
+                valid_files = utils.get_sorted_filenames(raw_mira, ".znc")
+                if valid_files:
+                    pass
+                else:
+                    logging.warning("No znc files found in, looking for mmclx")
+                    valid_files = utils.get_sorted_filenames(raw_mira, ".mmclx")
+
+            if valid_files:
+                pass
+            else:
+                logging.error("Please check path: Neither znc nor mmclx files found")
+                raise FileNotFoundError(
+                    "Neither znc nor mmclx files found "
+                    + f"{raw_mira}. Please check your input."
+                )
+
+            valid_files = utils.get_files_with_common_range(valid_files)
+
+            # get unique filetypes
+            filetypes = list({f.split(".")[-1].lower() for f in valid_files})
+
+            if len(filetypes) > 1:
+                raise TypeError(
+                    "mira2nc only supports a singlefile type as input",
+                    "either mmclx or znc",
+                )
+
+            keymap = _mirakeymap(filetypes[0])
+
             variables = list(keymap.keys())
             concat_lib.concatenate_files(
-                valid_filenames,
-                mmclx_filename,
+                valid_files,
+                input_filename,
                 variables=variables,
+                ignore=_miraignorevar(filetypes[0]),
                 allow_difference=["nave", "ovl"],
             )
         else:
-            mmclx_filename = raw_mira
+            input_filename = raw_mira
+            keymap = _mirakeymap(input_filename.split(".")[-1])
 
-        with Mira(mmclx_filename, site_meta) as mira:
+        with Mira(input_filename, site_meta) as mira:
             mira.init_data(keymap)
             if date is not None:
                 mira.screen_by_date(date)


### PR DESCRIPTION
Summary: Changes to mira2nc to support znc input (and STSR) for the whole of cloudnet

Added 2 helper functions to mira2nc which handle the specific keymap for the filetype (mmclx or znc) and removal of DropSize which according to the MetekManual has the dimensions range and Doppler (but no time as it is assumed to change little). This creates a concat conlfict and thus requires removal. Minor error catching for empty filelist as the recent change to be able to pass in a list requires a filetype and may lead to a potentially empty filelist.

Closes #83 