### PR TITLE
Extend ignorekeys for mira when znc files are processed for speedup

### DIFF
--- a/cloudnetpy/instruments/mira.py
+++ b/cloudnetpy/instruments/mira.py
@@ -97,10 +97,11 @@ def mira2nc(
                 # processing switched between different nffts without a hitch
                 # doppler is the third dimensions (other than time and height)
                 # that is relevant in znc files as they contain the spectra
+                # but it should be dropped rather than concatted
                 allow_difference=[
                     "nave",
                     "ovl",
-                    "doppler",
+                    # "doppler",
                     "nfft",
                 ],
             )
@@ -194,7 +195,7 @@ def _miraignorevar(filetype: str) -> list | None:
     # faster this way than previous patch as spectra are not being used in
     # cloudnetpy anyway and we therefore also do not need the Doppler dimension
     keymaps = {
-        "znc": ["DropSize", "SPCco", "SPCcx", "SPCcocxRe", "SPCcocxIm", "Doppler"],
+        "znc": ["DropSize", "SPCco", "SPCcx", "SPCcocxRe", "SPCcocxIm", "doppler"],
         "mmclx": None,
     }
 

--- a/cloudnetpy/instruments/mira.py
+++ b/cloudnetpy/instruments/mira.py
@@ -92,7 +92,17 @@ def mira2nc(
                 input_filename,
                 variables=variables,
                 ignore=_miraignorevar(filetypes[0]),
-                allow_difference=["nave", "ovl"],
+                # somewhat risky to allow varying nfft as the vel resolution
+                # will be different, but this allows for concatenating when
+                # processing switched between different nffts without a hitch
+                # doppler is the third dimensions (other than time and height)
+                # that is relevant in znc files as they contain the spectra
+                allow_difference=[
+                    "nave",
+                    "ovl",
+                    "doppler",
+                    "nfft",
+                ],
             )
         else:
             input_filename = raw_mira
@@ -181,7 +191,12 @@ def _miraignorevar(filetype: str) -> list | None:
     if filetype.lower() not in known_filetypes:
         raise ValueError(f"Filetype must be one of {known_filetypes}")
 
-    keymaps = {"znc": ["DropSize"], "mmclx": None}
+    # faster this way than previous patch as spectra are not being used in
+    # cloudnetpy anyway and we therefore also do not need the Doppler dimension
+    keymaps = {
+        "znc": ["DropSize", "SPCco", "SPCcx", "SPCcocxRe", "SPCcocxIm", "Doppler"],
+        "mmclx": None,
+    }
 
     return keymaps.get(filetype.lower(), keymaps.get("mmclx"))
 


### PR DESCRIPTION
Improvement of #84, completing #86  to speed up processing by dropping spectra from znc files (usually when a path or list of znc files has been passed).
This patch extends the previous keys to be ignored by the concat lib (was ["DropSize"] and is now ["DropSize", "SPCco", "SPCcx", "SPCcocxRe", "SPCcocxIm", "Doppler"])
This patch also added "nfft" to vary between files in case processing resp. number of fft (->nfft) was switched between consecutive files (potentially by scanning operation or similar)